### PR TITLE
Refactor decision handler

### DIFF
--- a/Sketch.js
+++ b/Sketch.js
@@ -169,21 +169,8 @@ function draw() {
 }
 
 function handleDecision(choice) {
-  var currentDriver = race.drivers[0]; // player controlled driver
-
-  if (choice === "yes") {
-    currentDriver.battery = Math.max(0, currentDriver.battery - 10);
-    currentDriver.pos -= 1; // moved up a spot
-    race.banner = "You pitted: -10 batt, +1 pos";
-  } else {
-    currentDriver.pos += 1; // lost a spot staying out
-    race.banner = "Stayed out: lost 1 position";
-  }
-
+  race.applyChoice(choice);
   race.bannerTimer = millis() + 2000;
-
-  race.decision  = null;
-  race.timeScale = 8;
 }
 
 // mouse controls


### PR DESCRIPTION
## Summary
- use `race.applyChoice` inside `handleDecision`
- drop unused `race.timeScale` reference

## Testing
- `node - <<'NODE'
const fs=require('fs');const vm=require('vm');
var DRIVERS=['PIERRE GASLY','FRANCO COLAPINTO'];
var custom={'PIERRE GASLY':{tyres:['soft','medium',null],twoStop:false},'FRANCO COLAPINTO':{tyres:['soft','medium',null],twoStop:false}};
function millis(){return 0;}
vm.runInThisContext(fs.readFileSync('race.js','utf8'));
vm.runInThisContext(fs.readFileSync('Sketch.js','utf8'));
HUD={draw:function(){}};
race=new Race(custom);
for(let i=0;i<3;i++){race.tick(); if(race.decision){Math.random=()=>0.6; handleDecision('yes');}}
console.log(race.drivers.map(d=>({name:d.name,pos:d.pos,batt:d.battery,tyre:d.tyre})));
NODE

------
https://chatgpt.com/codex/tasks/task_e_684f67583f5c8320a0c1410a0ef4234d