### PR TITLE
Improve race decision handling

### DIFF
--- a/Sketch.js
+++ b/Sketch.js
@@ -170,7 +170,6 @@ function draw() {
 
 function handleDecision(choice) {
   race.applyChoice(choice);
-  race.bannerTimer = millis() + 2000;
 }
 
 // mouse controls


### PR DESCRIPTION
## Summary
- refine Race.applyChoice so only one branch delta/random path applies
- clamp driver stats and compute punishment chance
- expose bannerText/Positive/PunishPct and show in HUD
- stop setting bannerTimer outside applyChoice
- normalize negative outcome probabilities when initializing decisions

## Testing
- `node --check race.js`
- `node --check Sketch.js`
- `node - <<'EOF'
const fs=require('fs');
var code=fs.readFileSync('race.js','utf8');
var vm=require('vm');
var context={console,millis:()=>0};
vm.createContext(context);
vm.runInContext(code,context);
context.DRIVERS=['A','B'];
var r=new context.Race({});
r.decision={yes:{driver:0,delta:{pos:-1},feedback:{text:'ok',positive:true}},no:{driver:0,delta:{},feedback:{text:'no',positive:false}}};
r.applyChoice('yes');
console.log('banner',r.bannerText,r.bannerPositive,r.bannerPunishPct,r.drivers[0].pos);
EOF

------
https://chatgpt.com/codex/tasks/task_e_684f692b8c60832084252f0c53dc2525