### PR TITLE
Update Race constructor API

### DIFF
--- a/Sketch.js
+++ b/Sketch.js
@@ -309,7 +309,7 @@ function mousePressed() {
             activeDriver++;
           } else {
             // last driver → launch the race
-            race = new Race(customStrategies);
+            race = new Race(DRIVERS, customStrategies);
             HUD.init(race);
             gameState = "race";
           }

--- a/race.js
+++ b/race.js
@@ -2,7 +2,7 @@
 //  LAP‑0  –  STRATEGY CENTER (race.js) v1.0
 //  Plain ES5 (no arrow functions). Load BEFORE sketch.js.
 //  Exposes:
-//    • Race(strategies)   – constructor(runnerStrategies) with methods:
+//    • Race(driverNames, strategies)   – constructor(nameArray, strategyMap) with methods:
 //        - tick()        : advance simulation & handle decisions
 //        - applyChoice(c): apply last YES/NO choice
 //        - findDriver(n) : lookup index by driver name
@@ -280,7 +280,7 @@ var staticDecisions = [
 /* -----------------------------------------------------------
    RACE ENGINE
 ----------------------------------------------------------- */
-function Race(strategies) {
+function Race(driverNames, strategies) {
   this.lap = 0;
   this.drivers = [];
   this.decision = null;
@@ -306,8 +306,8 @@ function Race(strategies) {
     });
   }
 
-  for (var i = 0; i < DRIVERS.length; i++) {
-    var name = DRIVERS[i];
+  for (var i = 0; i < driverNames.length; i++) {
+    var name = driverNames[i];
     var plan = strategies[name] || { tyres:["soft","medium",null], twoStop:false };
     var drv = new Driver(name, plan);
     drv.plannedTyres = plan.tyres.slice(1);


### PR DESCRIPTION
## Summary
- extend `Race` constructor to accept driver names
- pass `DRIVERS` list to `Race` when creating the race
- remove global `DRIVERS` usage inside `race.js`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684f7c2e29a483209881da2f1d132cc6